### PR TITLE
minor website updates

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -79,7 +79,7 @@
               <a class="nav-link" href="#section-jobs"><span class="navlink">Jobs</span></a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="https://ethswarm.medium.com" target="_blank">
+              <a class="nav-link" href="https://medium.com/ethereum-swarm" target="_blank">
                 <span class="navlink">Blog</span>
               </a>
             </li>
@@ -671,6 +671,7 @@
           <div class="footerlinks fl1">
             <p><a href="https://beehive.ethswarm.org" target="_blank">Mattermost</a></p>
             <p><a href="https://discord.gg/GU22h2utj6" target="_blank">Discord</a></p>
+            <p><a href="https://mailchi.mp/3871b41953e3/swarm-newsletter-signup" target="_blank">Newsletter</a></p>
             <p><a href="https://medium.com/ethereum-swarm" target="_blank">Blog</a></p>
             <p><a href="https://github.com/ethersphere" target="_blank">Github</a></p>
             <p><a href="https://twitter.com/ethswarm" target="_blank">Twitter</a></p>

--- a/src/index.html
+++ b/src/index.html
@@ -669,7 +669,6 @@
         <div class="col-sm-6 text-right">
           <p>Find Swarm on</p>
           <div class="footerlinks fl1">
-            <p><a href="https://beehive.ethswarm.org" target="_blank">Mattermost</a></p>
             <p><a href="https://discord.gg/GU22h2utj6" target="_blank">Discord</a></p>
             <p><a href="https://mailchi.mp/3871b41953e3/swarm-newsletter-signup" target="_blank">Newsletter</a></p>
             <p><a href="https://medium.com/ethereum-swarm" target="_blank">Blog</a></p>


### PR DESCRIPTION
In this update I:

- Changed blog post link from https://ethswarm.medium.com/ to https://medium.com/ethereum-swarm
- Added Newsletter sign-in to the footer
- Removed Mattermost link from the footer