### PR TITLE
Deploy using swarm-cli

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -22,25 +22,25 @@ jobs:
       - name: Install gulp
         run: npm install --global gulp-cli
 
-      - name: Setup swarm
-        run: |
-          printf ${{ secrets.KEY_PASS }} > password
-          mkdir -p ${HOME}/.ethereum/keystore
-          printf ${{ secrets.KEY_FILE }} > ${HOME}/.ethereum/keystore/UTC--2020-11-16T12-11-14.436704620Z--a852392e68c45598eb21070ac142274ad6097778
-          wget https://ethswarm.blob.core.windows.net/builds/swarm-linux-amd64-0.5.7-5ccfd995.tar.gz -O swarm.tar.gz
-          tar --strip-components 1 -xzf swarm.tar.gz
       - name: Build
         run: |
           yarn
           yarn gulp
           echo "swarm.ethereum.org" > ./dist/CNAME
+
+      - name: Upload using swarm-cli
+        env:
+          KEY_PASS: ${{ secrets.KEY_PASS }}
+          KEY_FILE: ${{ secrets.KEY_FILE }}
+          GATEWAY: ${{ secrets.GATEWAY }}
+        run: |
+          npm install --global @ethersphere/swarm-cli
+          echo $KEY_FILE > wallet.json
+          swarm-cli identity import --identity-name="uploader" --password="$KEY_PASS" wallet.json
+          swarm-cli --identity="uploader" --password="$KEY_PASS" feed upload --path "./dist" --bee-api-url $GATEWAY --topic "0000000000000000000000000000000000000000000000000000000000000000"
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-      - name: Swarm upload
-        run: |
-          rm ./dist/.nojekyll || true
-          FEED=$(./swarm --bzzapi https://swarm-public-0-swarm.prod.swarm-gateways.net --verbosity 6 --recursive --defaultpath ./dist/index.html up ./dist)
-          ./swarm --bzzapi https://swarm-gateways.net/ --verbosity 6 --password password feed update 0x"${FEED}"


### PR DESCRIPTION
This PR adds a github action to automatically deploy to website the swarm using the newly released swarm-cli tool.

I have chosen to use a gateway to upload in this case rather than installing and starting up a new Bee

I have a simple one set up for testing purposes for now which does not have file upload limits which i can supply the url for. I also have the relevant identities and passwords which will need to be added to secrets.